### PR TITLE
Fix component build issues

### DIFF
--- a/src/components/CollectionCard.svelte
+++ b/src/components/CollectionCard.svelte
@@ -4,7 +4,7 @@
   export let description: string | null = null;
   export let hero: string | null = null;
 </script>
-<a class="group block rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 hover:shadow" href={`/collections/${slug}`} sveltekit:prefetch>
+<a class="group block rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 hover:shadow" href={`/collections/${slug}`}>
   <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
     {#if hero}
       <img src={hero} alt={title} class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" />

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -26,6 +26,6 @@
       <h4 class="font-medium truncate">{summary.title}</h4>
       {#if summary.date}<p class="text-xs text-neutral-600 dark:text-neutral-400">{summary.date}</p>{/if}
     </a>
-    <SaveButton {item}={summary} />
+    <SaveButton item={summary} />
   </div>
 </article>

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -14,17 +14,19 @@
       return `${location.pathname}${q ? `?${q}` : ''}`;
     } catch { return href; }
   }
+  $: prev = normalize(pagination?.previous ?? null);
+  $: next = normalize(pagination?.next ?? null);
 </script>
 {#if pagination}
   <nav class="flex items-center justify-between mt-4" aria-label="Pagination">
-    {#if normalize(pagination.previous)}
-      <a class="px-3 py-1 rounded-lg border" href={normalize(pagination.previous)!}>Prev</a>
+    {#if prev}
+      <a class="px-3 py-1 rounded-lg border" href={prev}>Prev</a>
     {:else}
       <span class="px-3 py-1 rounded-lg border opacity-50 select-none">Prev</span>
     {/if}
     <span class="text-sm text-neutral-600 dark:text-neutral-300">Page {pagination.current} of {pagination.total}</span>
-    {#if normalize(pagination.next)}
-      <a class="px-3 py-1 rounded-lg border" href={normalize(pagination.next)!}>Next</a>
+    {#if next}
+      <a class="px-3 py-1 rounded-lg border" href={next}>Next</a>
     {:else}
       <span class="px-3 py-1 rounded-lg border opacity-50 select-none">Next</span>
     {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,8 +22,8 @@
       <CollectionCard
         title={c.title ?? 'Untitled'}
         slug={slugFromUrl(c.id)}
-        description={(c as any).description?.[0] ?? null}
-        hero={(c as any).image_url?.[0] ?? null}
+        description={c.description?.[0] ?? null}
+        hero={c.image_url?.[0] ?? null}
       />
     {/each}
   </div>

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -33,18 +33,20 @@
     if (sentinel) io.observe(sentinel);
     return () => io.disconnect();
   });
+
+  function updateSort(e: Event) {
+    const sb = (e.currentTarget as HTMLSelectElement).value;
+    const u = new URL(location.href);
+    if (sb) u.searchParams.set('sb', sb); else u.searchParams.delete('sb');
+    location.assign(u.toString());
+  }
 </script>
 <header class="mb-4 flex items-center justify-between gap-3">
   <h1 class="text-xl font-semibold">Collection Items</h1>
   <div class="flex items-center gap-2">
     <label class="text-sm">
       Sort:
-      <select class="ml-2 rounded border bg-transparent px-2 py-1" on:change={(e) => {
-        const sb = (e.currentTarget as HTMLSelectElement).value;
-        const u = new URL(location.href);
-        if (sb) u.searchParams.set('sb', sb); else u.searchParams.delete('sb');
-        location.assign(u.toString());
-      }}>
+      <select class="ml-2 rounded border bg-transparent px-2 py-1" on:change={updateSort}>
         <option value="">Relevance</option>
         <option value="date">Date ↑</option>
         <option value="date_desc">Date ↓</option>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -5,6 +5,7 @@
   const item = data.data.item ?? (data.data as any);
   const title = item?.title ?? 'Untitled';
   const summary = { id: data.canonical, title, thumb: data.cover ?? undefined, date: item?.date ?? null };
+  const resources: { url?: string }[] | undefined = (data.data as any).resources;
 </script>
 <a class="text-sm opacity-70 hover:opacity-100" href={document.referrer || '/'}>← Back</a>
 <header class="mt-2 flex items-center justify-between gap-3">
@@ -34,11 +35,11 @@
         </div>
       </div>
     {/if}
-    {#if (data.data as any).resources?.length}
+    {#if resources?.length}
       <div>
         <h2 class="font-semibold mb-2">Resources</h2>
         <ul class="list-disc pl-6">
-          {#each (data.data as any).resources as r, i}
+          {#each resources as r, i}
             {#if r.url}<li><a class="text-blue-600 hover:underline" href={r.url} target="_blank" rel="noopener">Download / View resource {i + 1}</a></li>{/if}
           {/each}
         </ul>

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -22,7 +22,7 @@
         <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`/item/${encodeURIComponent(btoa(id))}`}>
           <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800">
             {#if fav.byId[id].thumb}
-              <img src={fav.byId[id].thumb!} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />
+              <img src={fav.byId[id].thumb} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />
             {:else}
               <img src="/placeholder.svg" alt="No image" class="w-full h-full object-cover" loading="lazy" />
             {/if}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,7 +8,7 @@ export default {
     adapter: adapter(),
     alias: {
       $lib: 'src/lib',
-      $components: 'src/lib/components'
+      $components: 'src/components'
     }
   }
 };


### PR DESCRIPTION
## Summary
- remove invalid type assertions and non-null operators in Svelte templates
- centralize sort select handler and clean up pagination links
- point $components alias to actual components directory

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a060c0c408325beef78803136c191