### PR TITLE
Use load fetch and export params

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  export let data;
+  export let params;
   import { onMount } from 'svelte';
   import SearchBar from '../components/SearchBar.svelte';
   onMount(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js').catch(console.warn);
+      navigator.serviceWorker.register('/service-worker.js', { type: 'module' }).catch(console.warn);
     }
   });
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import CollectionCard from '$components/CollectionCard.svelte';
   import Pagination from '$components/Pagination.svelte';
   export let data: { data: SearchResponse };
+  export let params;
   const collections = data.data.results ?? [];
   function slugFromUrl(u: string): string {
     try {

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,7 +1,7 @@
 import type { PageLoad } from './$types';
 import { fetchCollections } from '$lib/api';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url, fetch }) => {
   const u = new URL('https://www.loc.gov/collections/');
   u.searchParams.set('fo', 'json');
   u.searchParams.set('at', 'results,pagination,facets');
@@ -9,6 +9,6 @@ export const load: PageLoad = async ({ url }) => {
     const v = url.searchParams.get(key);
     if (v) u.searchParams.set(key, v);
   }
-  const data = await fetchCollections(u.toString());
+  const data = await fetchCollections(fetch, u.toString());
   return { data };
 };

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   import Skeletons from '$components/Skeletons.svelte';
   import { onMount } from 'svelte';
   export let data: { data: SearchResponse; apiUrl: string };
+  export let params;
   let items = data.data.results ?? [];
   let next = data.data.pagination?.next ?? null;
   let loading = false;

--- a/src/routes/collections/[slug]/+page.ts
+++ b/src/routes/collections/[slug]/+page.ts
@@ -1,8 +1,8 @@
 import type { PageLoad } from './$types';
 import { collectionUrlFromSlug, fetchCollectionItems } from '$lib/api';
 
-export const load: PageLoad = async ({ url, params }) => {
+export const load: PageLoad = async ({ url, params, fetch }) => {
   const apiUrl = collectionUrlFromSlug(params.slug, url.searchParams);
-  const data = await fetchCollectionItems(apiUrl);
+  const data = await fetchCollectionItems(fetch, apiUrl);
   return { data, apiUrl };
 };

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -2,6 +2,7 @@
   import type { ItemResponse } from '$lib/types';
   import SaveButton from '$components/SaveButton.svelte';
   export let data: { data: ItemResponse; cover: string | null; canonical: string };
+  export let params;
   const item = data.data.item ?? (data.data as any);
   const title = item?.title ?? 'Untitled';
   const summary = { id: data.canonical, title, thumb: data.cover ?? undefined, date: item?.date ?? null };

--- a/src/routes/item/[id]/+page.ts
+++ b/src/routes/item/[id]/+page.ts
@@ -2,9 +2,9 @@ export const ssr = false;
 import type { PageLoad } from './$types';
 import { fetchItem, bestImageFrom } from '$lib/api';
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ params, fetch }) => {
   const decoded = atob(decodeURIComponent(params.id));
-  const data = await fetchItem(decoded);
+  const data = await fetchItem(fetch, decoded);
   const cover = bestImageFrom(data);
   return { data, cover, canonical: decoded };
 };

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  export let data;
+  export let params;
   import { favorites } from '$lib/stores/favorites';
   import { get } from 'svelte/store';
   $: fav = get(favorites);

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -4,6 +4,7 @@
   import FacetFilter from '../../components/FacetFilter.svelte';
   import Pagination from '../../components/Pagination.svelte';
   export let data: { data: SearchResponse; q: string };
+  export let params;
 </script>
 <h1 class="text-xl font-semibold mb-2">Search</h1>
 <p class="mb-4 text-neutral-600 dark:text-neutral-300">Results for “{data.q}”.</p>

--- a/src/routes/search/+page.ts
+++ b/src/routes/search/+page.ts
@@ -1,7 +1,7 @@
 import type { PageLoad } from './$types';
 import { fetchSearch } from '$lib/api';
 
-export const load: PageLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url, fetch }) => {
   const q = url.searchParams.get('q') ?? '';
   const u = new URL(`/search/?q=${encodeURIComponent(q)}`, 'https://www.loc.gov');
   const sb = url.searchParams.get('sb');
@@ -10,6 +10,6 @@ export const load: PageLoad = async ({ url }) => {
   if (sb) u.searchParams.set('sb', sb);
   if (fa) u.searchParams.set('fa', fa);
   if (c) u.searchParams.set('c', c);
-  const data = await fetchSearch(u.toString());
+  const data = await fetchSearch(fetch, u.toString());
   return { data, q };
 };

--- a/src/routes/viewer/[id]/+page.svelte
+++ b/src/routes/viewer/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import FullscreenImage from '$components/FullscreenImage.svelte';
   export let data: { url: string | null; canonical: string; title: string };
+  export let params;
 </script>
 <a class="text-sm opacity-70 hover:opacity-100" href={`/item/${encodeURIComponent(btoa(data.canonical))}`}>← Back to item</a>
 {#if data.url}

--- a/src/routes/viewer/[id]/+page.ts
+++ b/src/routes/viewer/[id]/+page.ts
@@ -2,9 +2,9 @@ export const ssr = false;
 import type { PageLoad } from './$types';
 import { fetchItem, bestImageFrom } from '$lib/api';
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ params, fetch }) => {
   const decoded = atob(decodeURIComponent(params.id));
-  const data = await fetchItem(decoded);
+  const data = await fetchItem(fetch, decoded);
   const url = bestImageFrom(data);
   return { url, canonical: decoded, title: data.item?.title ?? 'Image' };
 };


### PR DESCRIPTION
## Summary
- pass SvelteKit's load `fetch` into API helpers to avoid window fetch warnings
- export `params`/`data` in layout and pages to silence unknown prop warnings
- register service worker as module

## Testing
- `npx svelte-kit sync`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689a0bdd792483259186ae0758ae27f0