### PR TITLE
fix URL parsing in IIIF utilities and service worker

### DIFF
--- a/src/lib/utils/iiif.ts
+++ b/src/lib/utils/iiif.ts
@@ -1,6 +1,15 @@
 export function toIIIFLargest(url: string): string {
   if (!/\/iiif\//.test(url)) return url;
-  const u = new URL(url, 'https://');
+  // Some IIIF image URLs are protocol-relative (e.g. `//tile.loc.gov/...`).
+  // `new URL()` requires an absolute URL, so normalise these by prefixing
+  // a scheme before parsing. Using `https:` is fine as the Library of
+  // Congress serves images over HTTPS. The previous implementation attempted
+  // to supply a base of `"https://"`, which is an invalid base URL and
+  // caused `new URL()` to throw `TypeError: Failed to construct 'URL': Invalid
+  // base URL` when executed. By ensuring the string is absolute before
+  // constructing the URL object, we avoid the runtime error.
+  const normalized = url.startsWith('//') ? `https:${url}` : url;
+  const u = new URL(normalized);
   const path = u.pathname;
   const v3 = path.replace(/\/full\/[^/]+\/0\/(?:default|color|gray|bitonal)\.(jpg|png|webp)/,
     '/full/max/0/default.$1');

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -50,7 +50,11 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   const data = (event as any).data as any;
   if (data?.type === 'cache-item') {
     const item = data.payload as { id: string; thumb?: string | null };
-    const jsonUrl = new URL(item.id, 'https://');
+    // `new URL()` requires an absolute URL. `item.id` should already be
+    // absolute, but normalise protocol-relative IDs just in case to avoid
+    // `TypeError: Failed to construct 'URL': Invalid base URL`.
+    const id = item.id.startsWith('//') ? `https:${item.id}` : item.id;
+    const jsonUrl = new URL(id);
     jsonUrl.searchParams.set('fo', 'json');
     event.waitUntil((async () => {
       const cache = await caches.open(CACHE);


### PR DESCRIPTION
## Summary
- avoid TypeError by normalizing protocol-relative IIIF URLs before parsing
- prevent service worker crash when caching favorites by ensuring item URLs are absolute

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: Cannot find module './.svelte-kit/tsconfig.json')

------
https://chatgpt.com/codex/tasks/task_e_689a0f80b3cc8325ba838aead621104f