### PR TITLE
Fix routing warnings and improve image handling

### DIFF
--- a/src/lib/utils/iiif.ts
+++ b/src/lib/utils/iiif.ts
@@ -11,7 +11,10 @@ export function toIIIFLargest(url: string): string {
   const normalized = url.startsWith('//') ? `https:${url}` : url;
   const u = new URL(normalized);
   const path = u.pathname;
-  const v3 = path.replace(/\/full\/[^/]+\/0\/(?:default|color|gray|bitonal)\.(jpg|png|webp)/,
+  const pct = path.replace(/\/full\/pct:\d+\/0\/(?:default|color|gray|bitonal)\.(jpg|png|webp)/,
+    '/full/pct:100/0/default.$1');
+  if (pct !== path) { u.pathname = pct; return u.toString(); }
+  const v3 = path.replace(/\/full\/(?!pct:)[^/]+\/0\/(?:default|color|gray|bitonal)\.(jpg|png|webp)/,
     '/full/max/0/default.$1');
   if (v3 !== path) { u.pathname = v3; return u.toString(); }
   const v2 = path.replace(/\/full\/[^/]+\/0\/(?:default|native|color|gray)\.(jpg|png|webp)/,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   export let data;
-  export let params;
   import { onMount } from 'svelte';
   import SearchBar from '../components/SearchBar.svelte';
+  void data;
   onMount(() => {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/service-worker.js', { type: 'module' }).catch(console.warn);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,6 @@
   import CollectionCard from '$components/CollectionCard.svelte';
   import Pagination from '$components/Pagination.svelte';
   export let data: { data: SearchResponse };
-  export let params;
   const collections = data.data.results ?? [];
   function slugFromUrl(u: string): string {
     try {

--- a/src/routes/collections/+page.ts
+++ b/src/routes/collections/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+
+export const load: PageLoad = () => {
+  throw redirect(307, '/');
+};

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -5,7 +5,6 @@
   import Skeletons from '$components/Skeletons.svelte';
   import { onMount } from 'svelte';
   export let data: { data: SearchResponse; apiUrl: string };
-  export let params;
   let items = data.data.results ?? [];
   let next = data.data.pagination?.next ?? null;
   let loading = false;

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -2,7 +2,6 @@
   import type { ItemResponse } from '$lib/types';
   import SaveButton from '$components/SaveButton.svelte';
   export let data: { data: ItemResponse; cover: string | null; canonical: string };
-  export let params;
   const item = data.data.item ?? (data.data as any);
   const title = item?.title ?? 'Untitled';
   const summary = { id: data.canonical, title, thumb: data.cover ?? undefined, date: item?.date ?? null };

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   export let data;
-  export let params;
   import { favorites } from '$lib/stores/favorites';
   import { get } from 'svelte/store';
+  void data;
   $: fav = get(favorites);
   function clear() { if (confirm('Remove all saved items?')) favorites.clear(); }
 </script>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -4,7 +4,6 @@
   import FacetFilter from '../../components/FacetFilter.svelte';
   import Pagination from '../../components/Pagination.svelte';
   export let data: { data: SearchResponse; q: string };
-  export let params;
 </script>
 <h1 class="text-xl font-semibold mb-2">Search</h1>
 <p class="mb-4 text-neutral-600 dark:text-neutral-300">Results for “{data.q}”.</p>

--- a/src/routes/viewer/[id]/+page.svelte
+++ b/src/routes/viewer/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import FullscreenImage from '$components/FullscreenImage.svelte';
   export let data: { url: string | null; canonical: string; title: string };
-  export let params;
 </script>
 <a class="text-sm opacity-70 hover:opacity-100" href={`/item/${encodeURIComponent(btoa(data.canonical))}`}>← Back to item</a>
 {#if data.url}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -35,8 +35,12 @@ self.addEventListener('fetch', (event: FetchEvent) => {
       const cached = await caches.match(req);
       try {
         const res = await fetch(req);
-        const cache = await caches.open(CACHE);
-        cache.put(req, res.clone());
+        if (res.ok) {
+          try {
+            const cache = await caches.open(CACHE);
+            await cache.put(req, res.clone());
+          } catch {}
+        }
         return res;
       } catch {
         if (cached) return cached;


### PR DESCRIPTION
## Summary
- Remove unsupported `params` props from Svelte route components
- Handle pct-based IIIF image URLs and cache responses only when successful
- Redirect `/collections` to the home page to avoid 404s

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689a16ab1744832585e5adf5f976f750