### PR TITLE
Fix search pagination

### DIFF
--- a/src/routes/search/+page.ts
+++ b/src/routes/search/+page.ts
@@ -7,9 +7,11 @@ export const load: PageLoad = async ({ url, fetch }) => {
   const sb = url.searchParams.get('sb');
   const fa = url.searchParams.get('fa');
   const c = url.searchParams.get('c');
+  const sp = url.searchParams.get('sp');
   if (sb) u.searchParams.set('sb', sb);
   if (fa) u.searchParams.set('fa', fa);
   if (c) u.searchParams.set('c', c);
+  if (sp) u.searchParams.set('sp', sp);
   const data = await fetchSearch(fetch, u.toString());
   return { data, q };
 };


### PR DESCRIPTION
## Summary
- pass page (sp) query param to Library of Congress search API so results update when navigating pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npx svelte-kit sync`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a1f75ac808325b73ede602400ac7d