### PR TITLE
Fix collections page pagination to update results

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,8 @@
   import Pagination from '$components/Pagination.svelte';
   export let data: { data: SearchResponse };
   export let params;
-  const collections = data.data.results ?? [];
+  let collections = data.data.results ?? [];
+  $: collections = data.data.results ?? [];
   function slugFromUrl(u: string): string {
     try {
       const { pathname } = new URL(u);


### PR DESCRIPTION
## Summary
- make collection list reactive so navigating pages updates results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689a1f75ac808325b73ede602400ac7d