### PR TITLE
feat: refine iOS-inspired styling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -5,6 +5,12 @@
 :root { color-scheme: light dark; }
 html, body, #svelte { height: 100%; }
 
+@layer base {
+  body {
+    @apply font-sans bg-neutral-50 text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-50;
+  }
+}
+
 :focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
 
 .skeleton { position: relative; overflow: hidden; }

--- a/src/components/CollectionCard.svelte
+++ b/src/components/CollectionCard.svelte
@@ -4,7 +4,10 @@
   export let description: string | null = null;
   export let hero: string | null = null;
 </script>
-<a class="group block rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 hover:shadow" href={`/collections/${slug}`}>
+<a
+  class="group block overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg"
+  href={`/collections/${slug}`}
+>
   <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
     {#if hero}
       <img src={hero} alt={title} class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" />

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -11,7 +11,7 @@
     thumb
   };
 </script>
-<article class="rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+<article class="overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
   <a href={`/item/${encodeURIComponent(btoa(summary.id))}`} aria-label={`Open ${summary.title}`}>
     <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
       {#if summary.thumb}

--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -10,12 +10,16 @@
 </script>
 <form class="relative" on:submit|preventDefault={onSubmit} role="search">
   <input
-    class="w-full rounded-xl border border-neutral-300 dark:border-neutral-700 bg-white/70 dark:bg-neutral-900 px-4 py-2 pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500"
+    class="w-full rounded-full border border-neutral-300 dark:border-neutral-700 bg-white/80 dark:bg-neutral-900/80 px-4 py-2 pr-10 shadow-sm placeholder-neutral-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition"
     placeholder="Search the Library of Congress"
     bind:value={q}
     aria-label="Search all collections"
   />
-  <button type="submit" class="absolute right-1 top-1/2 -translate-y-1/2 px-3 py-1 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800" aria-label="Search">
+  <button
+    type="submit"
+    class="absolute right-1 top-1/2 -translate-y-1/2 p-2 rounded-full text-neutral-500 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800"
+    aria-label="Search"
+  >
     🔎
   </button>
 </form>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,18 +12,18 @@
   });
 </script>
 <svelte:window on:keydown={(e) => { if (e.key === 'Escape') history.state && history.back(); }} />
-<div class="min-h-screen bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-50">
-  <header class="sticky top-0 z-40 backdrop-blur bg-white/70 dark:bg-neutral-950/70 border-b border-neutral-200 dark:border-neutral-800">
+<div class="flex min-h-screen flex-col bg-gradient-to-b from-neutral-50 to-neutral-100 dark:from-neutral-900 dark:to-neutral-950">
+  <header class="sticky top-0 z-40 bg-white/80 dark:bg-neutral-900/80 backdrop-blur-md border-b border-neutral-200 dark:border-neutral-800 shadow-sm">
     <div class="container flex items-center gap-3 py-3">
       <a href="/" class="font-semibold tracking-tight">LOC Collections</a>
-      <nav class="ml-auto flex items-center gap-3">
-        <a href="/saved" class="rounded-lg px-3 py-1 hover:bg-neutral-100 dark:hover:bg-neutral-800">Saved</a>
-        <a href="/search" class="rounded-lg px-3 py-1 hover:bg-neutral-100 dark:hover:bg-neutral-800">Search</a>
+      <nav class="ml-auto flex items-center gap-3 text-sm">
+        <a href="/saved" class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Saved</a>
+        <a href="/search" class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Search</a>
       </nav>
     </div>
     <div class="container py-3"><SearchBar /></div>
   </header>
-  <main class="container py-6"><slot /></main>
+  <main class="container flex-1 py-8"><slot /></main>
   <footer class="container py-10 text-sm text-neutral-600 dark:text-neutral-400">
     <p>Data from the Library of Congress JSON API. This is an unofficial demo.</p>
   </footer>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,7 +8,19 @@ module.exports = {
   ],
   theme: {
     extend: {
-      container: { center: true, padding: '1rem' }
+      container: { center: true, padding: '1rem' },
+      fontFamily: {
+        sans: [
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'Roboto',
+          'Helvetica Neue',
+          'Arial',
+          'Noto Sans',
+          'sans-serif'
+        ]
+      }
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- refresh app typography with system font stack
- polish layout and components with iOS-style gradients, blur and rounded cards

## Testing
- `npx svelte-kit sync`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a2c29e8888325a21c8a366d45da75