### PR TITLE
fix: static site build and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm install
+      - run: npm run build
+        env:
+          BASE_PATH: /loc-collections
+      - run: touch build/.nojekyll
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "loc-collections-browser",
       "version": "0.1.0",
       "devDependencies": {
-        "@sveltejs/adapter-auto": "^3.2.4",
         "@sveltejs/kit": "^2.7.3",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
         "@types/node": "^22.5.0",
@@ -18,7 +17,8 @@
         "svelte-check": "^3.8.5",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.5.4",
-        "vite": "^5.4.2"
+        "vite": "^5.4.2",
+        "@sveltejs/adapter-static": "^3.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -849,19 +849,6 @@
         "acorn": "^8.9.0"
       }
     },
-    "node_modules/@sveltejs/adapter-auto": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.3.1.tgz",
-      "integrity": "sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-meta-resolve": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@sveltejs/kit": "^2.0.0"
-      }
-    },
     "node_modules/@sveltejs/kit": {
       "version": "2.27.3",
       "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.27.3.tgz",
@@ -1647,17 +1634,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inflight": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/adapter-auto": "^3.2.4",
     "@sveltejs/kit": "^2.7.3",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "@types/node": "^22.5.0",
@@ -20,6 +19,7 @@
     "svelte-check": "^3.8.5",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "@sveltejs/adapter-static": "^3.0.3"
   }
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,11 +1,14 @@
 // svelte.config.js
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 export default {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
+    paths: {
+      base: process.env.BASE_PATH ?? ''
+    },
     alias: {
       $lib: 'src/lib',
       $components: 'src/components'


### PR DESCRIPTION
## Summary
- use static adapter with configurable base path for GitHub Pages
- deploy built `build` directory with `.nojekyll`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find package '@sveltejs/adapter-static')*

------
https://chatgpt.com/codex/tasks/task_e_689b329433ec8325bc0cad0a3409772c