### PR TITLE
fix: add fallback for static adapter

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,13 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 export default {
   preprocess: vitePreprocess(),
   kit: {
-    adapter: adapter(),
+    // Use a fallback page so that dynamic routes like `/item/[id]` can be
+    // handled when using the static adapter. Without this, the build fails
+    // with "Encountered dynamic routes" because the adapter doesn't know how
+    // to prerender paths with parameters. The fallback ensures that requests
+    // for any non‑prerendered route serve the app shell (index.html), allowing
+    // the client side router to resolve the correct page at runtime.
+    adapter: adapter({ fallback: 'index.html' }),
     paths: {
       base: process.env.BASE_PATH ?? ''
     },


### PR DESCRIPTION
## Summary
- handle dynamic SvelteKit routes by adding index.html fallback for static adapter

## Testing
- `npm run check` *(fails: Cannot find module './.svelte-kit/tsconfig.json')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b45ed7244832597f3cdf49ad6ee71