### PR TITLE
Fix base path handling for search and collection pages

### DIFF
--- a/src/components/CollectionCard.svelte
+++ b/src/components/CollectionCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   export let title: string;
   export let slug: string;
   export let description: string | null = null;
@@ -6,13 +7,13 @@
 </script>
 <a
   class="group block overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg"
-  href={`/collections/${slug}`}
+  href={`${base}/collections/${slug}`}
 >
   <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
     {#if hero}
       <img src={hero} alt={title} class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" />
     {:else}
-      <img src="/placeholder.svg" alt="Placeholder" class="w-full h-full object-cover" loading="lazy" />
+      <img src={`${base}/placeholder.svg`} alt="Placeholder" class="w-full h-full object-cover" loading="lazy" />
     {/if}
   </div>
   <div class="p-4">

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -2,6 +2,7 @@
   import SaveButton from './SaveButton.svelte';
   import type { ResultItem, ItemSummary } from '$lib/types';
   import { bestImageFrom } from '$lib/api';
+  import { base } from '$app/paths';
   export let item!: ResultItem;
   const thumb = bestImageFrom(item);
   const summary: ItemSummary = {
@@ -12,17 +13,17 @@
   };
 </script>
 <article class="overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
-  <a href={`/item/${encodeURIComponent(btoa(summary.id))}`} aria-label={`Open ${summary.title}`}>
+  <a href={`${base}/item/${encodeURIComponent(btoa(summary.id))}`} aria-label={`Open ${summary.title}`}>
     <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
       {#if summary.thumb}
         <img src={summary.thumb} alt={summary.title} class="w-full h-full object-cover" loading="lazy" />
       {:else}
-        <img src="/placeholder.svg" alt="No image available" class="w-full h-full object-cover" loading="lazy" />
+        <img src={`${base}/placeholder.svg`} alt="No image available" class="w-full h-full object-cover" loading="lazy" />
       {/if}
     </div>
   </a>
   <div class="p-3 flex items-center justify-between gap-2">
-    <a class="min-w-0" href={`/item/${encodeURIComponent(btoa(summary.id))}`}>
+    <a class="min-w-0" href={`${base}/item/${encodeURIComponent(btoa(summary.id))}`}>
       <h4 class="font-medium truncate">{summary.title}</h4>
       {#if summary.date}<p class="text-xs text-neutral-600 dark:text-neutral-400">{summary.date}</p>{/if}
     </a>

--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { base } from '$app/paths';
   export let initial = '';
   let q = initial;
   function onSubmit(e: Event) {
     e.preventDefault();
     const term = q?.trim();
-    if (term) goto(`/search?q=${encodeURIComponent(term)}`);
+    if (term) goto(`${base}/search?q=${encodeURIComponent(term)}`);
   }
 </script>
 <form class="relative" on:submit|preventDefault={onSubmit} role="search">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,13 +2,16 @@
   export let data;
   export let params;
   import { onMount } from 'svelte';
+  import { base } from '$app/paths';
   import SearchBar from '../components/SearchBar.svelte';
   import '../app.css';
   void data;
   void params;
   onMount(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js', { type: 'module' }).catch(console.warn);
+      navigator.serviceWorker
+        .register(`${base}/service-worker.js`, { type: 'module' })
+        .catch(console.warn);
     }
   });
 </script>
@@ -16,10 +19,10 @@
 <div class="flex min-h-screen flex-col bg-gradient-to-b from-neutral-50 to-neutral-100 dark:from-neutral-900 dark:to-neutral-950">
   <header class="sticky top-0 z-40 bg-white/80 dark:bg-neutral-900/80 backdrop-blur-md border-b border-neutral-200 dark:border-neutral-800 shadow-sm">
     <div class="container flex items-center gap-3 py-3">
-      <a href="/" class="font-semibold tracking-tight">LOC Collections</a>
+      <a href={base + '/'} class="font-semibold tracking-tight">LOC Collections</a>
       <nav class="ml-auto flex items-center gap-3 text-sm">
-        <a href="/saved" class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Saved</a>
-        <a href="/search" class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Search</a>
+        <a href={base + '/saved'} class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Saved</a>
+        <a href={base + '/search'} class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Search</a>
       </nav>
     </div>
     <div class="container py-3"><SearchBar /></div>

--- a/src/routes/item/[id]/+page.svelte
+++ b/src/routes/item/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ItemResponse } from '$lib/types';
   import SaveButton from '$components/SaveButton.svelte';
+  import { base } from '$app/paths';
   export let data: { data: ItemResponse; cover: string | null; canonical: string };
   export let params;
   const item = data.data.item ?? (data.data as any);
@@ -9,13 +10,13 @@
   const resources: { url?: string }[] | undefined = (data.data as any).resources;
   void params;
 </script>
-<a class="text-sm opacity-70 hover:opacity-100" href={document.referrer || '/'}>← Back</a>
+<a class="text-sm opacity-70 hover:opacity-100" href={document.referrer || base + '/'}>← Back</a>
 <header class="mt-2 flex items-center justify-between gap-3">
   <h1 class="text-2xl font-semibold">{title}</h1>
   <SaveButton item={summary} />
 </header>
 {#if data.cover}
-  <a href={`/viewer/${encodeURIComponent(btoa(summary.id))}`} class="block my-4" aria-label="Open fullscreen viewer">
+  <a href={`${base}/viewer/${encodeURIComponent(btoa(summary.id))}`} class="block my-4" aria-label="Open fullscreen viewer">
     <img src={data.cover} alt={title} class="w-full max-h-[60vh] object-contain rounded-xl bg-neutral-100 dark:bg-neutral-800" />
   </a>
 {/if}
@@ -32,7 +33,7 @@
         <h2 class="font-semibold mb-2">Subjects</h2>
         <div class="flex gap-2 flex-wrap">
           {#each (item.subjects ?? item.subject ?? []) as s}
-            <a href={`/search?fa=subject:${encodeURIComponent(s)}`} class="text-sm rounded-full border px-3 py-1 hover:bg-neutral-100 dark:hover:bg-neutral-800">{s}</a>
+            <a href={`${base}/search?fa=subject:${encodeURIComponent(s)}`} class="text-sm rounded-full border px-3 py-1 hover:bg-neutral-100 dark:hover:bg-neutral-800">{s}</a>
           {/each}
         </div>
       </div>

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -3,6 +3,7 @@
   export let params;
   import { favorites } from '$lib/stores/favorites';
   import { get } from 'svelte/store';
+  import { base } from '$app/paths';
   void data;
   void params;
   $: fav = get(favorites);
@@ -13,7 +14,7 @@
   <div class="flex gap-2">
     <button class="rounded-lg border px-3 py-1" on:click={clear}>Clear All</button>
     {#if fav.ids.length}
-      <a class="rounded-lg border px-3 py-1" href={`/viewer/${encodeURIComponent(btoa(fav.ids[0]))}`}>Open First in Viewer</a>
+      <a class="rounded-lg border px-3 py-1" href={`${base}/viewer/${encodeURIComponent(btoa(fav.ids[0]))}`}>Open First in Viewer</a>
     {/if}
   </div>
 </header>
@@ -23,12 +24,12 @@
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
     {#each fav.ids as id}
       {#if fav.byId[id]}
-        <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`/item/${encodeURIComponent(btoa(id))}`}>
+        <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`${base}/item/${encodeURIComponent(btoa(id))}`}> 
           <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800">
             {#if fav.byId[id].thumb}
               <img src={fav.byId[id].thumb} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />
             {:else}
-              <img src="/placeholder.svg" alt="No image" class="w-full h-full object-cover" loading="lazy" />
+              <img src={`${base}/placeholder.svg`} alt="No image" class="w-full h-full object-cover" loading="lazy" />
             {/if}
           </div>
           <div class="p-2 text-sm">

--- a/src/routes/viewer/[id]/+page.svelte
+++ b/src/routes/viewer/[id]/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import FullscreenImage from '$components/FullscreenImage.svelte';
+  import { base } from '$app/paths';
   export let data: { url: string | null; canonical: string; title: string };
   export let params;
   void params;
 </script>
-<a class="text-sm opacity-70 hover:opacity-100" href={`/item/${encodeURIComponent(btoa(data.canonical))}`}>← Back to item</a>
+<a class="text-sm opacity-70 hover:opacity-100" href={`${base}/item/${encodeURIComponent(btoa(data.canonical))}`}>← Back to item</a>
 {#if data.url}
   <h1 class="sr-only">{data.title}</h1>
   <FullscreenImage src={data.url} alt={data.title} />


### PR DESCRIPTION
## Summary
- Use SvelteKit `base` path for service worker, nav links, and search navigation
- Update collection, item, and viewer links to respect base path
- Fix placeholder image paths for deployments under subdirectories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b5f0e82a883258d535a079a3b5d06