### PR TITLE
feat: allow saving collections and improve save feedback

### DIFF
--- a/src/components/CollectionCard.svelte
+++ b/src/components/CollectionCard.svelte
@@ -1,25 +1,36 @@
 <script lang="ts">
   import { base } from '$app/paths';
+  import SaveButton from './SaveButton.svelte';
+  import type { CollectionSummary } from '$lib/types';
+  export let id: string;
   export let title: string;
   export let slug: string;
   export let description: string | null = null;
   export let hero: string | null = null;
+  const summary: CollectionSummary = {
+    id: id.replace('http://', 'https://'),
+    title,
+    slug,
+    thumb: hero ?? undefined
+  };
 </script>
-<a
-  class="group block overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg"
-  href={`${base}/collections/${slug}`}
->
-  <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
-    {#if hero}
-      <img src={hero} alt={title} class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" />
-    {:else}
-      <img src={`${base}/placeholder.svg`} alt="Placeholder" class="w-full h-full object-cover" loading="lazy" />
-    {/if}
+<article class="group overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
+  <a href={`${base}/collections/${slug}`}> 
+    <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
+      {#if hero}
+        <img src={hero} alt={title} class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" loading="lazy" />
+      {:else}
+        <img src={`${base}/placeholder.svg`} alt="Placeholder" class="w-full h-full object-cover" loading="lazy" />
+      {/if}
+    </div>
+  </a>
+  <div class="p-4 flex items-start justify-between gap-2">
+    <a class="min-w-0" href={`${base}/collections/${slug}`}>
+      <h3 class="font-semibold mb-1 line-clamp-2">{title}</h3>
+      {#if description}
+        <p class="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{description}</p>
+      {/if}
+    </a>
+    <SaveButton item={summary} />
   </div>
-  <div class="p-4">
-    <h3 class="font-semibold mb-1 line-clamp-2">{title}</h3>
-    {#if description}
-      <p class="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{description}</p>
-    {/if}
-  </div>
-</a>
+</article>

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -1,19 +1,36 @@
 <script lang="ts">
   import SaveButton from './SaveButton.svelte';
-  import type { ResultItem, ItemSummary } from '$lib/types';
+  import type { ResultItem, ItemSummary, CollectionSummary } from '$lib/types';
   import { bestImageFrom } from '$lib/api';
   import { base } from '$app/paths';
   export let item!: ResultItem;
   const thumb = bestImageFrom(item);
-  const summary: ItemSummary = {
-    id: item.id.replace('http://', 'https://'),
-    title: item.title ?? 'Untitled',
-    date: item.date ?? null,
-    thumb
-  };
+  const isCollection = item.id.includes('/collections/');
+  let summary: ItemSummary | CollectionSummary;
+  if (isCollection) {
+    const match = item.id.match(/\/collections\/([^/?#]+)/);
+    const slug = match ? match[1] : item.id;
+    summary = {
+      id: item.id.replace('http://', 'https://'),
+      title: item.title ?? 'Untitled',
+      slug,
+      thumb
+    } satisfies CollectionSummary;
+  } else {
+    summary = {
+      id: item.id.replace('http://', 'https://'),
+      title: item.title ?? 'Untitled',
+      date: item.date ?? null,
+      thumb
+    } satisfies ItemSummary;
+  }
+  const href = isCollection
+    ? `${base}/collections/${(summary as CollectionSummary).slug}`
+    : `${base}/item/${encodeURIComponent(btoa(summary.id))}`;
+  const itemDate = isCollection ? null : (summary as ItemSummary).date;
 </script>
 <article class="overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
-  <a href={`${base}/item/${encodeURIComponent(btoa(summary.id))}`} aria-label={`Open ${summary.title}`}>
+  <a href={href} aria-label={`Open ${summary.title}`}>
     <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
       {#if summary.thumb}
         <img src={summary.thumb} alt={summary.title} class="w-full h-full object-cover" loading="lazy" />
@@ -23,9 +40,13 @@
     </div>
   </a>
   <div class="p-3 flex items-center justify-between gap-2">
-    <a class="min-w-0" href={`${base}/item/${encodeURIComponent(btoa(summary.id))}`}>
+    <a class="min-w-0" href={href}>
       <h4 class="font-medium truncate">{summary.title}</h4>
-      {#if summary.date}<p class="text-xs text-neutral-600 dark:text-neutral-400">{summary.date}</p>{/if}
+      {#if isCollection}
+        <p class="text-xs text-amber-700 dark:text-amber-400">Collection</p>
+      {:else if itemDate}
+        <p class="text-xs text-neutral-600 dark:text-neutral-400">{itemDate}</p>
+      {/if}
     </a>
     <SaveButton item={summary} />
   </div>

--- a/src/components/SaveButton.svelte
+++ b/src/components/SaveButton.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
   import { favorites } from '$lib/stores/favorites';
   import type { ItemSummary } from '$lib/types';
-  import { get } from 'svelte/store';
   export let item!: ItemSummary;
-  $: saved = get(favorites).ids.includes(item.id);
-  function toggle() { if (saved) favorites.removeFavorite(item.id); else favorites.saveFavorite(item); }
+  // reactively determine if this item is saved
+  $: saved = $favorites.ids.includes(item.id);
+  function toggle() {
+    if (saved) favorites.removeFavorite(item.id);
+    else favorites.saveFavorite(item);
+  }
 </script>
-<button class={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm ${saved ? 'bg-emerald-600 text-white border-emerald-600' : 'hover:bg-neutral-100 dark:hover:bg-neutral-800'}`} on:click={toggle} aria-pressed={saved} aria-label={saved ? 'Remove from saved' : 'Save item'}>
+<button
+  class={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm ${saved ? 'bg-emerald-600 text-white border-emerald-600' : 'hover:bg-neutral-100 dark:hover:bg-neutral-800'}`}
+  on:click={toggle}
+  aria-pressed={saved}
+  aria-label={saved ? 'Remove from saved' : item.slug ? 'Save collection' : 'Save item'}
+>
   {#if saved}✓ Saved{:else}+ Save{/if}
 </button>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,4 +68,8 @@ export type ItemSummary = {
   title: string;
   thumb?: string | null;
   date?: string | null;
+  /** Slug is present when the summary represents a collection */
+  slug?: string;
 };
+
+export type CollectionSummary = ItemSummary & { slug: string };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,7 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
     {#each collections as c}
       <CollectionCard
+        id={c.id}
         title={c.title ?? 'Untitled'}
         slug={slugFromUrl(c.id)}
         description={c.description?.[0] ?? null}

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -2,19 +2,21 @@
   export let data;
   export let params;
   import { favorites } from '$lib/stores/favorites';
-  import { get } from 'svelte/store';
   import { base } from '$app/paths';
   void data;
   void params;
-  $: fav = get(favorites);
+  // expose the store value reactively
+  $: fav = $favorites;
+  // find the first saved item (not a collection) for viewer shortcut
+  $: firstItemId = fav.ids.find((id) => !fav.byId[id]?.slug);
   function clear() { if (confirm('Remove all saved items?')) favorites.clear(); }
 </script>
 <header class="mb-4 flex items-center justify-between">
   <h1 class="text-xl font-semibold">Saved Items</h1>
   <div class="flex gap-2">
     <button class="rounded-lg border px-3 py-1" on:click={clear}>Clear All</button>
-    {#if fav.ids.length}
-      <a class="rounded-lg border px-3 py-1" href={`${base}/viewer/${encodeURIComponent(btoa(fav.ids[0]))}`}>Open First in Viewer</a>
+    {#if firstItemId}
+      <a class="rounded-lg border px-3 py-1" href={`${base}/viewer/${encodeURIComponent(btoa(firstItemId))}`}>Open First in Viewer</a>
     {/if}
   </div>
 </header>
@@ -24,19 +26,35 @@
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
     {#each fav.ids as id}
       {#if fav.byId[id]}
-        <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`${base}/item/${encodeURIComponent(btoa(id))}`}> 
-          <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800">
-            {#if fav.byId[id].thumb}
-              <img src={fav.byId[id].thumb} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />
-            {:else}
-              <img src={`${base}/placeholder.svg`} alt="No image" class="w-full h-full object-cover" loading="lazy" />
-            {/if}
-          </div>
-          <div class="p-2 text-sm">
-            <p class="font-medium truncate">{fav.byId[id].title}</p>
-            {#if fav.byId[id].date}<p class="text-xs opacity-70">{fav.byId[id].date}</p>{/if}
-          </div>
-        </a>
+        {#if fav.byId[id].slug}
+          <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`${base}/collections/${fav.byId[id].slug}`}>
+            <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800">
+              {#if fav.byId[id].thumb}
+                <img src={fav.byId[id].thumb} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />
+              {:else}
+                <img src={`${base}/placeholder.svg`} alt="No image" class="w-full h-full object-cover" loading="lazy" />
+              {/if}
+            </div>
+            <div class="p-2 text-sm">
+              <p class="font-medium truncate">{fav.byId[id].title}</p>
+              <p class="text-xs text-amber-700 dark:text-amber-400">Collection</p>
+            </div>
+          </a>
+        {:else}
+          <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`${base}/item/${encodeURIComponent(btoa(id))}`}>
+            <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800">
+              {#if fav.byId[id].thumb}
+                <img src={fav.byId[id].thumb} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />
+              {:else}
+                <img src={`${base}/placeholder.svg`} alt="No image" class="w-full h-full object-cover" loading="lazy" />
+              {/if}
+            </div>
+            <div class="p-2 text-sm">
+              <p class="font-medium truncate">{fav.byId[id].title}</p>
+              {#if fav.byId[id].date}<p class="text-xs opacity-70">{fav.byId[id].date}</p>{/if}
+            </div>
+          </a>
+        {/if}
       {/if}
     {/each}
   </div>


### PR DESCRIPTION
## Summary
- make save button reactive so labels update immediately
- enable saving collections from listings and search results
- show saved collections with labels in saved items page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TSConfckParseError: failed to resolve extends './.svelte-kit/tsconfig.json')*


------
https://chatgpt.com/codex/tasks/task_e_689b9fa648a48325ad7b1af0fd510c4c