### PR TITLE
feat: enhance pagination UI

### DIFF
--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,34 +1,84 @@
 <script lang="ts">
-  import type { Pagination } from '$lib/types';
-  export let pagination: Pagination | undefined;
-  function normalize(href: string | null): string | null {
-    if (!href) return null;
-    try {
-      const u = new URL(href);
-      const params = new URLSearchParams(location.search);
-      for (const key of ['sp','c','sb','fa']) {
-        const v = u.searchParams.get(key);
-        if (v) params.set(key, v);
-      }
-      const q = params.toString();
-      return `${location.pathname}${q ? `?${q}` : ''}`;
-    } catch { return href; }
+import type { Pagination } from '$lib/types';
+export let pagination: Pagination | undefined;
+
+// Normalize pagination links so that search parameters from the current
+// location (such as filters and sort order) are preserved when navigating
+// between pages.
+function normalize(href: string | null): string | null {
+  if (!href) return null;
+  try {
+    const u = new URL(href);
+    const params = new URLSearchParams(location.search);
+    for (const key of ['sp', 'c', 'sb', 'fa']) {
+      const v = u.searchParams.get(key);
+      if (v) params.set(key, v);
+    }
+    const q = params.toString();
+    return `${location.pathname}${q ? `?${q}` : ''}`;
+  } catch {
+    return href;
   }
-  $: prev = normalize(pagination?.previous ?? null);
-  $: next = normalize(pagination?.next ?? null);
+}
+
+$: prev = normalize(pagination?.previous ?? null);
+$: next = normalize(pagination?.next ?? null);
+$: first = normalize(pagination?.first ?? null);
+$: last = normalize(pagination?.last ?? null);
+$: pageList =
+  pagination?.page_list?.map((p) => ({ ...p, url: normalize(p.url ?? null) })) ?? null;
 </script>
 {#if pagination}
-  <nav class="flex items-center justify-between mt-4" aria-label="Pagination">
-    {#if prev}
-      <a class="px-3 py-1 rounded-lg border" href={prev}>Prev</a>
-    {:else}
-      <span class="px-3 py-1 rounded-lg border opacity-50 select-none">Prev</span>
-    {/if}
-    <span class="text-sm text-neutral-600 dark:text-neutral-300">Page {pagination.current} of {pagination.total}</span>
-    {#if next}
-      <a class="px-3 py-1 rounded-lg border" href={next}>Next</a>
-    {:else}
-      <span class="px-3 py-1 rounded-lg border opacity-50 select-none">Next</span>
-    {/if}
+  <nav class="mt-4 flex justify-center" aria-label="Pagination">
+    <span class="sr-only">Page {pagination.current} of {pagination.total}</span>
+    <ul class="flex items-center gap-2">
+      <li>
+        {#if first}
+          <a class="px-3 py-1 rounded-lg border" href={first} aria-label="First page">&laquo;</a>
+        {:else}
+          <span class="px-3 py-1 rounded-lg border opacity-50 select-none">&laquo;</span>
+        {/if}
+      </li>
+      <li>
+        {#if prev}
+          <a class="px-3 py-1 rounded-lg border" href={prev} aria-label="Previous page">&lsaquo;</a>
+        {:else}
+          <span class="px-3 py-1 rounded-lg border opacity-50 select-none">&lsaquo;</span>
+        {/if}
+      </li>
+      {#if pageList}
+        {#each pageList as page}
+          <li>
+            {#if page.url}
+              <a
+                href={page.url}
+                class="px-3 py-1 rounded-lg border"
+                class:bg-neutral-200={typeof page.number === 'number' && page.number === pagination.current}
+                class:dark\:bg-neutral-700={typeof page.number === 'number' && page.number === pagination.current}
+                aria-current={typeof page.number === 'number' && page.number === pagination.current ? 'page' : undefined}
+              >
+                {page.number}
+              </a>
+            {:else}
+              <span class="px-3 py-1 select-none">{page.number}</span>
+            {/if}
+          </li>
+        {/each}
+      {/if}
+      <li>
+        {#if next}
+          <a class="px-3 py-1 rounded-lg border" href={next} aria-label="Next page">&rsaquo;</a>
+        {:else}
+          <span class="px-3 py-1 rounded-lg border opacity-50 select-none">&rsaquo;</span>
+        {/if}
+      </li>
+      <li>
+        {#if last}
+          <a class="px-3 py-1 rounded-lg border" href={last} aria-label="Last page">&raquo;</a>
+        {:else}
+          <span class="px-3 py-1 rounded-lg border opacity-50 select-none">&raquo;</span>
+        {/if}
+      </li>
+    </ul>
   </nav>
 {/if}


### PR DESCRIPTION
## Summary
- add first/last/previous/next links and numeric page list for pagination
- preserve search params across pagination links

## Testing
- `npm run build`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689ba66101048325946d837de226ca7a