### PR TITLE
Refine Save button tooltip and sizing

### DIFF
--- a/src/components/SaveButton.svelte
+++ b/src/components/SaveButton.svelte
@@ -4,16 +4,27 @@
   export let item!: ItemSummary;
   // reactively determine if this item is saved
   $: saved = $favorites.ids.includes(item.id);
+  let animating = false;
   function toggle() {
     if (saved) favorites.removeFavorite(item.id);
     else favorites.saveFavorite(item);
+    animating = true;
+    setTimeout(() => (animating = false), 300);
   }
 </script>
 <button
-  class={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm ${saved ? 'bg-emerald-600 text-white border-emerald-600' : 'hover:bg-neutral-100 dark:hover:bg-neutral-800'}`}
+  class={`group/save relative inline-flex h-8 w-8 items-center justify-center rounded-full border p-2 text-sm transition-transform active:scale-95 ${saved ? 'bg-emerald-600 text-white border-emerald-600' : 'hover:bg-neutral-100 dark:hover:bg-neutral-800'}`}
   on:click={toggle}
   aria-pressed={saved}
   aria-label={saved ? 'Remove from saved' : item.slug ? 'Save collection' : 'Save item'}
 >
-  {#if saved}✓ Saved{:else}+ Save{/if}
+  {#if animating}
+    <span class="absolute inset-0 rounded-full bg-emerald-400 opacity-75 animate-ping"></span>
+  {/if}
+  <span class="relative z-10 text-lg leading-none">{#if saved}✓{:else}+{/if}</span>
+  <span
+    class="pointer-events-none absolute left-1/2 bottom-full mb-2 -translate-x-1/2 rounded bg-neutral-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity duration-200 group-hover/save:opacity-100 group-focus/save:opacity-100"
+  >
+    {saved ? 'Saved' : 'Save'}
+  </span>
 </button>


### PR DESCRIPTION
## Summary
- Ensure Save button stays circular with fixed dimensions
- Show tooltip only when hovering the button using a named group

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find module './$types'; svelte-check found 48 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ba54900a88325acf99c6f734e48fd