### PR TITLE
Fix incorrect saved item when paging

### DIFF
--- a/src/components/CollectionCard.svelte
+++ b/src/components/CollectionCard.svelte
@@ -7,7 +7,9 @@
   export let slug: string;
   export let description: string | null = null;
   export let hero: string | null = null;
-  const summary: CollectionSummary = {
+  let summary: CollectionSummary;
+
+  $: summary = {
     id: id.replace('http://', 'https://'),
     title,
     slug,

--- a/src/components/ItemCard.svelte
+++ b/src/components/ItemCard.svelte
@@ -4,30 +4,37 @@
   import { bestImageFrom } from '$lib/api';
   import { base } from '$app/paths';
   export let item!: ResultItem;
-  const thumb = bestImageFrom(item);
-  const isCollection = item.id.includes('/collections/');
+  let thumb: string | undefined;
+  let isCollection: boolean;
   let summary: ItemSummary | CollectionSummary;
-  if (isCollection) {
-    const match = item.id.match(/\/collections\/([^/?#]+)/);
-    const slug = match ? match[1] : item.id;
-    summary = {
-      id: item.id.replace('http://', 'https://'),
-      title: item.title ?? 'Untitled',
-      slug,
-      thumb
-    } satisfies CollectionSummary;
-  } else {
-    summary = {
-      id: item.id.replace('http://', 'https://'),
-      title: item.title ?? 'Untitled',
-      date: item.date ?? null,
-      thumb
-    } satisfies ItemSummary;
+  let href: string;
+  let itemDate: string | null;
+
+  $: {
+    thumb = bestImageFrom(item);
+    isCollection = item.id.includes('/collections/');
+    if (isCollection) {
+      const match = item.id.match(/\/collections\/([^/?#]+)/);
+      const slug = match ? match[1] : item.id;
+      summary = {
+        id: item.id.replace('http://', 'https://'),
+        title: item.title ?? 'Untitled',
+        slug,
+        thumb
+      } satisfies CollectionSummary;
+    } else {
+      summary = {
+        id: item.id.replace('http://', 'https://'),
+        title: item.title ?? 'Untitled',
+        date: item.date ?? null,
+        thumb
+      } satisfies ItemSummary;
+    }
+    href = isCollection
+      ? `${base}/collections/${(summary as CollectionSummary).slug}`
+      : `${base}/item/${encodeURIComponent(btoa(summary.id))}`;
+    itemDate = isCollection ? null : (summary as ItemSummary).date;
   }
-  const href = isCollection
-    ? `${base}/collections/${(summary as CollectionSummary).slug}`
-    : `${base}/item/${encodeURIComponent(btoa(summary.id))}`;
-  const itemDate = isCollection ? null : (summary as ItemSummary).date;
 </script>
 <article class="overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
   <a href={href} aria-label={`Open ${summary.title}`}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,7 @@
 <p class="mb-6 text-neutral-600 dark:text-neutral-300">Browse digitized collections. Click a card to dive in, then scroll to load more.</p>
 {#if collections.length}
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-    {#each collections as c}
+    {#each collections as c (c.id)}
       <CollectionCard
         id={c.id}
         title={c.title ?? 'Untitled'}

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -70,7 +70,7 @@
   </section>
 {/if}
 <section class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-  {#each items as item}<ItemCard {item} />{/each}
+  {#each items as item (item.id)}<ItemCard {item} />{/each}
 </section>
 {#if !done}
   <div bind:this={sentinel} class="h-12" aria-hidden="true" />

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -24,10 +24,10 @@
   <p class="text-neutral-600 dark:text-neutral-400">You haven’t saved anything yet.</p>
 {:else}
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-    {#each fav.ids as id}
+    {#each fav.ids as id (id)}
       {#if fav.byId[id]}
         {#if fav.byId[id].slug}
-          <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`${base}/collections/${fav.byId[id].slug}`}>
+          <a class="block rounded-xl overflow-hidden border border-neutral-200 dark:border-neutral-800" href={`${base}/collections/${fav.byId[id].slug}`}> 
             <div class="aspect-[4/3] bg-neutral-100 dark:bg-neutral-800">
               {#if fav.byId[id].thumb}
                 <img src={fav.byId[id].thumb} alt={fav.byId[id].title} class="w-full h-full object-cover" loading="lazy" />

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -12,7 +12,7 @@
 {#if data.data.facets}<FacetFilter facets={data.data.facets} />{/if}
 {#if data.data.results?.length}
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-4">
-    {#each data.data.results as item}<ItemCard {item} />{/each}
+    {#each data.data.results as item (item.id)}<ItemCard {item} />{/each}
   </div>
   <Pagination pagination={data.data.pagination} />
 {:else}


### PR DESCRIPTION
## Summary
- Recompute item and collection summaries whenever their props change
- Key item and collection lists so pagination loads fresh card instances

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689ba84cc5bc83258bd0b65a8eeac1ae