### PR TITLE
feat: add book icon to site title

### DIFF
--- a/src/components/BookIcon.svelte
+++ b/src/components/BookIcon.svelte
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6">
+  <!-- Left cover (angled) -->
+  <path d="M6 14 C20 8, 28 12, 32 18 L32 50 C28 46, 20 42, 6 46 Z" fill="white"/>
+  
+  <!-- Right cover (angled) -->
+  <path d="M58 14 C44 8, 36 12, 32 18 L32 50 C36 46, 44 42, 58 46 Z" fill="white"/>
+  
+  <!-- Center spine with perspective -->
+  <path d="M32 18 L32 50" />
+  
+  <!-- Left page curves -->
+  <path d="M10 22 C20 20, 28 24, 28 24" />
+  <path d="M10 30 C20 28, 28 32, 28 32" />
+  
+  <!-- Right page curves -->
+  <path d="M36 24 C44 20, 54 22, 54 22" />
+  <path d="M36 32 C44 28, 54 30, 54 30" />
+  
+  <!-- Bottom edge for 3D effect -->
+  <path d="M6 46 L32 50 L58 46" />
+</svg>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { onMount } from 'svelte';
   import { base } from '$app/paths';
   import SearchBar from '../components/SearchBar.svelte';
+  import BookIcon from '../components/BookIcon.svelte';
   import '../app.css';
   void data;
   void params;
@@ -19,7 +20,10 @@
 <div class="flex min-h-screen flex-col bg-gradient-to-b from-neutral-50 to-neutral-100 dark:from-neutral-900 dark:to-neutral-950">
   <header class="sticky top-0 z-40 bg-white/80 dark:bg-neutral-900/80 backdrop-blur-md border-b border-neutral-200 dark:border-neutral-800 shadow-sm">
     <div class="container flex items-center gap-3 py-3">
-      <a href={base + '/'} class="font-semibold tracking-tight">LOC Collections</a>
+      <a href={base + '/'} class="flex items-center gap-2 font-semibold tracking-tight">
+        <BookIcon />
+        LOC Collections
+      </a>
       <nav class="ml-auto flex items-center gap-3 text-sm">
         <a href={base + '/saved'} class="rounded-full px-3 py-1 transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800">Saved</a>
       </nav>


### PR DESCRIPTION
## Summary
- add book-shaped SVG icon component
- display icon alongside site title in the header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx svelte-kit sync`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689c9472aea883259f6b59ce6eb7f745