### PR TITLE
Ensure sorting reloads collection items

### DIFF
--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -14,6 +14,12 @@
   let done = !next;
   let sentinel: HTMLDivElement;
   let showFacets = false;
+
+  $: {
+    items = data.data.results ?? [];
+    next = data.data.pagination?.next ?? null;
+    done = !next;
+  }
   async function loadMore() {
     if (!next || loading) return;
     loading = true;


### PR DESCRIPTION
## Summary
- Reset results and pagination when sort order changes so new data is shown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689c9de836c4832593229a6860950086