### PR TITLE
feat: add modern collection details section

### DIFF
--- a/src/components/CollectionDetails.svelte
+++ b/src/components/CollectionDetails.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import SaveButton from './SaveButton.svelte';
+  import type { CollectionSummary } from '$lib/types';
+  export let id: string;
+  export let slug: string;
+  export let title: string;
+  export let description: string | null = null;
+  export let hero: string | null = null;
+  let summary: CollectionSummary;
+  $: summary = {
+    id: id.replace('http://', 'https://'),
+    title,
+    slug,
+    thumb: hero ?? undefined
+  } satisfies CollectionSummary;
+</script>
+
+<section class="mb-8 overflow-hidden rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 backdrop-blur shadow-sm">
+  {#if hero}
+    <div class="relative h-48 md:h-64 overflow-hidden">
+      <img src={hero} alt={title} class="absolute inset-0 w-full h-full object-cover" />
+      <div class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+    </div>
+  {/if}
+  <div class="p-6 flex flex-col gap-4">
+    <div class="flex items-start justify-between gap-4">
+      <h1 class="text-3xl font-bold leading-tight">{title}</h1>
+      <SaveButton item={summary} />
+    </div>
+    {#if description}
+      <p class="text-neutral-600 dark:text-neutral-300 leading-relaxed">{description}</p>
+    {/if}
+  </div>
+</section>
+

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -3,6 +3,8 @@
   import ItemCard from '$components/ItemCard.svelte';
   import FacetFilter from '$components/FacetFilter.svelte';
   import Skeletons from '$components/Skeletons.svelte';
+  import CollectionDetails from '$components/CollectionDetails.svelte';
+  import { bestImageFrom } from '$lib/api';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
@@ -14,6 +16,12 @@
   let done = !next;
   let sentinel: HTMLDivElement;
   let showFacets = false;
+  let collectionTitle = data.data.title ?? params.slug;
+  let collectionDescription: string | null = Array.isArray((data.data as any).description)
+    ? (data.data as any).description[0]
+    : ((data.data as any).description ?? null);
+  let collectionId = (data.data as any).id ?? data.apiUrl.split('?')[0];
+  let hero = bestImageFrom(data.data as any);
 
   $: {
     items = data.data.results ?? [];
@@ -53,6 +61,13 @@
   }
   void params;
 </script>
+<CollectionDetails
+  id={collectionId}
+  slug={params.slug}
+  title={collectionTitle}
+  description={collectionDescription}
+  hero={hero}
+/>
 <header class="mb-4 flex items-center justify-between gap-3">
   <h1 class="text-xl font-semibold">Collection Items</h1>
   <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add CollectionDetails component with hero image, title, description, and save support
- show collection details section at top of collection page

## Testing
- `npm run build`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689ca533ea7083259df6f2434e53a5af