### PR TITLE
Add build preprocess for SPA fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview --port 4173",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "preprocess": "node scripts/preprocess.js",
+    "postbuild": "npm run preprocess"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.7.3",

--- a/scripts/preprocess.js
+++ b/scripts/preprocess.js
@@ -1,0 +1,18 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+const buildDir = 'build';
+const src = join(buildDir, 'index.html');
+const dest = join(buildDir, '404.html');
+
+async function copyFallback() {
+  try {
+    await fs.copyFile(src, dest);
+    console.log(`Copied ${src} -> ${dest}`);
+  } catch (err) {
+    console.error('Failed to copy fallback page', err);
+    process.exit(1);
+  }
+}
+
+copyFallback();


### PR DESCRIPTION
## Summary
- copy `build/index.html` to `build/404.html` so deep links on GitHub Pages load the SPA
- wire up `npm run preprocess` via `postbuild`

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689cc56944cc8325bbf647373cf78bae