### PR TITLE
Humanize collection titles and surface metadata

### DIFF
--- a/src/components/CollectionDetails.svelte
+++ b/src/components/CollectionDetails.svelte
@@ -6,6 +6,7 @@
   export let title: string;
   export let description: string | null = null;
   export let hero: string | null = null;
+  export let metadata: Record<string, string[]> = {};
   let summary: CollectionSummary;
   $: summary = {
     id: id.replace('http://', 'https://'),
@@ -29,6 +30,17 @@
     </div>
     {#if description}
       <p class="text-neutral-600 dark:text-neutral-300 leading-relaxed">{description}</p>
+    {/if}
+    {#if Object.keys(metadata).length}
+      <dl
+        class="grid gap-x-2 gap-y-1 text-sm text-neutral-700 dark:text-neutral-300"
+        style="grid-template-columns: auto 1fr;"
+      >
+        {#each Object.entries(metadata) as [k, v]}
+          <dt class="font-medium capitalize">{k}</dt>
+          <dd>{v.join(', ')}</dd>
+        {/each}
+      </dl>
     {/if}
   </div>
 </section>

--- a/src/lib/utils/strings.ts
+++ b/src/lib/utils/strings.ts
@@ -1,0 +1,5 @@
+export function slugToTitle(slug: string): string {
+  return slug
+    .replace(/[\-_]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   import Skeletons from '$components/Skeletons.svelte';
   import CollectionDetails from '$components/CollectionDetails.svelte';
   import { bestImageFrom } from '$lib/api';
+  import { slugToTitle } from '$lib/utils/strings';
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
@@ -16,17 +17,24 @@
   let done = !next;
   let sentinel: HTMLDivElement;
   let showFacets = false;
-  let collectionTitle = data.data.title ?? params.slug;
+  let collectionTitle = data.data.title ?? slugToTitle(params.slug);
   let collectionDescription: string | null = Array.isArray((data.data as any).description)
     ? (data.data as any).description[0]
     : ((data.data as any).description ?? null);
   let collectionId = (data.data as any).id ?? data.apiUrl.split('?')[0];
   let hero = bestImageFrom(data.data as any);
+  let metadata: Record<string, string[]> = {};
 
   $: {
     items = data.data.results ?? [];
     next = data.data.pagination?.next ?? null;
     done = !next;
+    const raw = data.data as any;
+    metadata = {};
+    for (const key of ['subject', 'format', 'partof']) {
+      const v = raw[key];
+      if (Array.isArray(v) && v.length) metadata[key] = v;
+    }
   }
   async function loadMore() {
     if (!next || loading) return;
@@ -67,6 +75,7 @@
   title={collectionTitle}
   description={collectionDescription}
   hero={hero}
+  metadata={metadata}
 />
 <header class="mb-4 flex items-center justify-between gap-3">
   <h1 class="text-xl font-semibold">Collection Items</h1>


### PR DESCRIPTION
## Summary
- Add utility to convert collection slugs into readable titles
- Extract subjects, formats, and related collections from collection API responses
- Display extracted metadata in CollectionDetails component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find module './$types'; svelte-check found 53 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9838110832585cfe17d36dada90