### PR TITLE
Humanize collection titles and surface metadata

### DIFF
--- a/src/components/CollectionDetails.svelte
+++ b/src/components/CollectionDetails.svelte
@@ -6,6 +6,7 @@
   export let title: string;
   export let description: string | null = null;
   export let hero: string | null = null;
+  export let metadata: Record<string, string[]> = {};
   let summary: CollectionSummary;
   $: summary = {
     id: id.replace('http://', 'https://'),
@@ -29,6 +30,17 @@
     </div>
     {#if description}
       <p class="text-neutral-600 dark:text-neutral-300 leading-relaxed">{description}</p>
+    {/if}
+    {#if Object.keys(metadata).length}
+      <dl
+        class="grid gap-x-2 gap-y-1 text-sm text-neutral-700 dark:text-neutral-300"
+        style="grid-template-columns: auto 1fr;"
+      >
+        {#each Object.entries(metadata) as [k, v]}
+          <dt class="font-medium capitalize">{k}</dt>
+          <dd>{v.join(', ')}</dd>
+        {/each}
+      </dl>
     {/if}
   </div>
 </section>

--- a/src/routes/collections/[slug]/+page.svelte
+++ b/src/routes/collections/[slug]/+page.svelte
@@ -16,17 +16,24 @@
   let done = !next;
   let sentinel: HTMLDivElement;
   let showFacets = false;
-  let collectionTitle = data.data.title ?? params.slug;
+  let collectionTitle = data.data.title ?? items[0]?.partof?.[0] ?? params.slug;
   let collectionDescription: string | null = Array.isArray((data.data as any).description)
     ? (data.data as any).description[0]
     : ((data.data as any).description ?? null);
   let collectionId = (data.data as any).id ?? data.apiUrl.split('?')[0];
   let hero = bestImageFrom(data.data as any);
+  let metadata: Record<string, string[]> = {};
 
   $: {
     items = data.data.results ?? [];
     next = data.data.pagination?.next ?? null;
     done = !next;
+    const raw = data.data as any;
+    metadata = {};
+    for (const key of ['subject', 'format', 'partof']) {
+      const v = raw[key];
+      if (Array.isArray(v) && v.length) metadata[key] = v;
+    }
   }
   async function loadMore() {
     if (!next || loading) return;
@@ -67,6 +74,7 @@
   title={collectionTitle}
   description={collectionDescription}
   hero={hero}
+  metadata={metadata}
 />
 <header class="mb-4 flex items-center justify-between gap-3">
   <h1 class="text-xl font-semibold">Collection Items</h1>


### PR DESCRIPTION
## Summary
- Use title from API or item metadata instead of slug conversion
- Remove unused slug-to-title utility
- Display extracted metadata in CollectionDetails component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: svelte-check: not found)*
- `npm install` *(fails: unable to fetch packages; MaxListenersExceededWarning)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9838110832585cfe17d36dada90